### PR TITLE
Explicitly decalre functions used in TorService.c to build with NDK 26+

### DIFF
--- a/src/feature/api/org_torproject_jni_TorService.c
+++ b/src/feature/api/org_torproject_jni_TorService.c
@@ -3,10 +3,13 @@
  * Copyright (c) 2007-2019, The Tor Project, Inc. */
 /* See LICENSE for licensing information */
 
-#include "tor_api.h"
 #include "org_torproject_jni_TorService.h"
 #include "orconfig.h"
 #include "lib/malloc/malloc.h"
+#include "app/main/shutdown.h"
+#include "feature/api/tor_api.h"
+#include "feature/api/tor_api_internal.h"
+
 
 #include <jni.h>
 #include <stdbool.h>


### PR DESCRIPTION
Android NDK toolchain 26 and 27 uses a newer version of clang that treats these implicitly invoked function calls as errors instead of warnings. since 25.2.9519653 is deprecated this is one of the things we **need** todo in order to use a supported NDK toolchain