### PR TITLE
Remove unused apiGetProviderVersion

### DIFF
--- a/src/feature/api/org_torproject_jni_TorService.c
+++ b/src/feature/api/org_torproject_jni_TorService.c
@@ -247,14 +247,6 @@ Java_org_torproject_jni_TorService_mainConfigurationFree
   tor_main_configuration_free(cfg);
 }
 
-JNIEXPORT jstring JNICALL
-Java_org_torproject_jni_TorService_apiGetProviderVersion
-(JNIEnv *env, jobject _ignore)
-{
-  UNUSED(_ignore);
-  return (*env)->NewStringUTF(env, tor_api_get_provider_version());
-}
-
 JNIEXPORT jint JNICALL
 Java_org_torproject_jni_TorService_runMain
 (JNIEnv *env, jobject thisObj)

--- a/src/feature/api/org_torproject_jni_TorService.h
+++ b/src/feature/api/org_torproject_jni_TorService.h
@@ -46,15 +46,6 @@ Java_org_torproject_jni_TorService_mainConfigurationFree
 
 /*
  * Class:     org_torproject_jni_TorService
- * Method:    apiGetProviderVersion
- * Signature: ()Ljava/lang/String;
- */
-JNIEXPORT jstring JNICALL
-Java_org_torproject_jni_TorService_apiGetProviderVersion
-(JNIEnv *, jobject);
-
-/*
- * Class:     org_torproject_jni_TorService
  * Method:    runMain
  * Signature: ()I
  */


### PR DESCRIPTION
This is never invoked in tor-android. tor-android, instead a gradle var is exposed in `TorService.java`:
```java
public static final String VERSION_NAME = BuildConfig.VERSION_NAME;
```